### PR TITLE
remove a useless thread

### DIFF
--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -268,8 +268,8 @@ void ApiServer::start()
 
     cnote << "Api server listening on port " + to_string(m_acceptor.local_endpoint().port())
           << (m_password.empty() ? "." : ". Authentication needed.");
-    m_workThread = std::thread{boost::bind(&ApiServer::begin_accept, this)};
     m_running.store(true, std::memory_order_relaxed);
+    begin_accept();
 }
 
 void ApiServer::stop()
@@ -280,7 +280,6 @@ void ApiServer::stop()
 
     m_acceptor.cancel();
     m_acceptor.close();
-    m_workThread.join();
     m_running.store(false, std::memory_order_relaxed);
 
     // Dispose all sessions (if any)

--- a/libapicore/ApiServer.h
+++ b/libapicore/ApiServer.h
@@ -85,7 +85,6 @@ private:
 
     int lastSessionId = 0;
 
-    std::thread m_workThread;
     std::atomic<bool> m_readonly = {false};
     std::string m_password = "";
     std::atomic<bool> m_running = {false};


### PR DESCRIPTION
The `begin_accept` method is already asynchronous, so the `m_workThread` will quit immediately after being instantiated, which is a waste of cpu cycles(though not much).